### PR TITLE
Feature: Créer un hook personnalisé useOutsideClick pour gérer les cl…

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -224,6 +224,7 @@
     "createGroup": "Create a group",
     "joinGroup": "Join a group",
     "collapse": "Collapse sidebar",
-    "expand": "Expand sidebar"
+    "expand": "Expand sidebar",
+    "groupNamePlaceholder": "Enter group name..."
   }
 }

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -224,6 +224,7 @@
     "createGroup": "Créer un groupe",
     "joinGroup": "Rejoindre un groupe",
     "collapse": "Réduire le menu",
-    "expand": "Développer le menu"
+    "expand": "Développer le menu",
+    "groupNamePlaceholder": "Nom du groupe..."
   }
 }

--- a/src/components/layout/SideMenu.tsx
+++ b/src/components/layout/SideMenu.tsx
@@ -1,10 +1,58 @@
-import React from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import GroupList from './GroupList';
+import { groupService } from '../../services/api';
+import useOutsideClick from "../../hooks/useOutsideClick";
 
 const SideMenu: React.FC = () => {
   const { t } = useTranslation();
+  const [isCreatingGroup, setIsCreatingGroup] = useState(false);
+  const [newGroupName, setNewGroupName] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Fonction pour créer un groupe, mémorisée pour éviter des re-render inutiles
+  const createGroup = useCallback(() => {
+    if (newGroupName.trim()) {
+      groupService.createGroup({
+        name: newGroupName.trim(),
+        description: ''
+      })
+        .then(() => {
+          setIsCreatingGroup(false);
+          setNewGroupName('');
+          // Recharger la page pour afficher le nouveau groupe
+          window.location.reload();
+        })
+        .catch((error) => console.error("Erreur lors de la création du groupe:", error));
+    } else {
+      // Annuler si le nom est vide
+      setIsCreatingGroup(false);
+      setNewGroupName('');
+    }
+  }, [newGroupName]);
+
+  // Utiliser notre hook personnalisé pour gérer les clics en dehors
+  useOutsideClick(inputRef, createGroup, isCreatingGroup);
+
+  // Focus sur l'input quand on passe en mode création
+  useEffect(() => {
+    if (isCreatingGroup && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [isCreatingGroup]);
+
+  // Gestion des touches Entrée et Escape pour l'input
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      createGroup();
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      setIsCreatingGroup(false);
+      setNewGroupName('');
+    }
+  };
 
   return (
     <div className="bg-white h-full shadow-md flex-shrink-0 border-r border-gray-200 w-full overflow-hidden">
@@ -15,15 +63,29 @@ const SideMenu: React.FC = () => {
         <GroupList />
 
         <div className="mt-6 space-y-2">
-          <Link
-            to="/groups/new"
-            className="flex items-center px-4 py-2 text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 w-full"
-          >
-            <svg className="mr-3 h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-              <path fillRule="evenodd" d="M10 5a1 1 0 011 1v3h3a1 1 0 110 2h-3v3a1 1 0 11-2 0v-3H6a1 1 0 110-2h3V6a1 1 0 011-1z" clipRule="evenodd" />
-            </svg>
-            {t('sidemenu.createGroup')}
-          </Link>
+          {isCreatingGroup ? (
+            <div className="relative">
+              <input
+                ref={inputRef}
+                type="text"
+                value={newGroupName}
+                onChange={(e) => setNewGroupName(e.target.value)}
+                onKeyDown={handleKeyDown}
+                className="w-full px-4 py-2 text-sm border rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
+                placeholder={t('sidemenu.groupNamePlaceholder') || 'Enter group name...'}
+              />
+            </div>
+          ) : (
+            <button
+              onClick={() => setIsCreatingGroup(true)}
+              className="flex items-center px-4 py-2 text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 w-full"
+            >
+              <svg className="mr-3 h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+                <path fillRule="evenodd" d="M10 5a1 1 0 011 1v3h3a1 1 0 110 2h-3v3a1 1 0 11-2 0v-3H6a1 1 0 110-2h3V6a1 1 0 011-1z" clipRule="evenodd" />
+              </svg>
+              {t('sidemenu.createGroup')}
+            </button>
+          )}
 
           <Link
             to="/invitations"

--- a/src/hooks/useOutsideClick.ts
+++ b/src/hooks/useOutsideClick.ts
@@ -1,0 +1,39 @@
+import { useEffect, RefObject, useCallback } from 'react';
+
+/**
+ * Hook pour détecter les clics en dehors d'un élément spécifié
+ * @param ref - Référence React à l'élément à surveiller
+ * @param handler - Fonction à exécuter lorsqu'un clic est détecté en dehors de l'élément
+ * @param active - Indique si la détection est active ou non (utile pour les modales conditionnelles)
+ */
+const useOutsideClick = <T extends HTMLElement>(
+  ref: RefObject<T | null>,
+  handler: () => void,
+  active: boolean = true
+): void => {
+  // Mémoriser le gestionnaire d'événements pour éviter des re-render inutiles
+  const memoizedHandler = useCallback(
+    (event: MouseEvent) => {
+      // Vérifier que la référence est définie et que le clic n'est pas à l'intérieur de l'élément
+      if (active && ref.current && !ref.current.contains(event.target as Node)) {
+        handler();
+      }
+    },
+    [ref, handler, active]
+  );
+
+  useEffect(() => {
+    // N'ajouter l'écouteur que si le hook est actif
+    if (active) {
+      document.addEventListener('mousedown', memoizedHandler);
+
+      // Nettoyer l'écouteur à la désactivation du hook ou au démontage du composant
+      return () => {
+        document.removeEventListener('mousedown', memoizedHandler);
+      };
+    }
+    return undefined;
+  }, [active, memoizedHandler]);
+};
+
+export default useOutsideClick;


### PR DESCRIPTION
This pull request introduces several new features and improvements to the `SideMenu` component, including the ability to create a new group directly from the sidebar. Additionally, it adds a new custom hook for handling outside clicks and updates translations to support the new feature.

### New Features and Improvements:

* **Group Creation in Sidebar:**
  * [`src/components/layout/SideMenu.tsx`](diffhunk://#diff-27553c53b932a97282a35f4524fde3fcf3025af6c82d90e4131c60b2181f3919L1-R55): Added state management for group creation, including input handling and submission logic. This includes the use of `useState`, `useRef`, `useEffect`, and `useCallback` hooks. [[1]](diffhunk://#diff-27553c53b932a97282a35f4524fde3fcf3025af6c82d90e4131c60b2181f3919L1-R55) [[2]](diffhunk://#diff-27553c53b932a97282a35f4524fde3fcf3025af6c82d90e4131c60b2181f3919L18-R88)

* **Custom Hook for Outside Click Handling:**
  * [`src/hooks/useOutsideClick.ts`](diffhunk://#diff-e5a5e216e6b1b3c68a57363eef52e68cdd44466b4ddde1be6400b5548b379795R1-R39): Introduced a new custom hook `useOutsideClick` to detect clicks outside a specified element and trigger a handler function. This is used to manage the group creation input field.

### Translation Updates:

* **English Translations:**
  * [`public/locales/en/translation.json`](diffhunk://#diff-8e77946ee485378b13babd5fe6bdc1707b77dce605ac6723d7a5b4494dc94925L227-R228): Added a new placeholder text for the group name input field.

* **French Translations:**
  * [`public/locales/fr/translation.json`](diffhunk://#diff-db68874ec38c82339488bf71b2c6986967df85e8920b9dc9755e603a6ec7c4b0L227-R228): Added a new placeholder text for the group name input field.…ics en dehors des éléments