### PR TITLE
Amélioration du SideMenu avec GroupCreationForm et mise à jour du hoo…

### DIFF
--- a/src/components/layout/SideMenu.tsx
+++ b/src/components/layout/SideMenu.tsx
@@ -1,58 +1,39 @@
-import React, { useState, useRef, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import GroupList from './GroupList';
-import { groupService } from '../../services/api';
-import useOutsideClick from "../../hooks/useOutsideClick";
+import GroupCreationForm from '../common/forms/GroupCreationForm';
 
 const SideMenu: React.FC = () => {
   const { t } = useTranslation();
-  const [isCreatingGroup, setIsCreatingGroup] = useState(false);
-  const [newGroupName, setNewGroupName] = useState('');
-  const inputRef = useRef<HTMLInputElement>(null);
+  const [groupListKey, setGroupListKey] = useState(0);
 
-  // Fonction pour créer un groupe, mémorisée pour éviter des re-render inutiles
-  const createGroup = useCallback(() => {
-    if (newGroupName.trim()) {
-      groupService.createGroup({
-        name: newGroupName.trim(),
-        description: ''
-      })
-        .then(() => {
-          setIsCreatingGroup(false);
-          setNewGroupName('');
-          // Recharger la page pour afficher le nouveau groupe
-          window.location.reload();
-        })
-        .catch((error) => console.error("Erreur lors de la création du groupe:", error));
-    } else {
-      // Annuler si le nom est vide
-      setIsCreatingGroup(false);
-      setNewGroupName('');
-    }
-  }, [newGroupName]);
+  // Fonction pour rafraîchir la liste des groupes
+  const refreshGroupList = useCallback(() => {
+    setGroupListKey(prevKey => prevKey + 1);
+  }, []);
 
-  // Utiliser notre hook personnalisé pour gérer les clics en dehors
-  useOutsideClick(inputRef, createGroup, isCreatingGroup);
+  // Gestionnaire de création de groupe réussie
+  const handleGroupCreated = useCallback(() => {
+    refreshGroupList();
+  }, [refreshGroupList]);
 
-  // Focus sur l'input quand on passe en mode création
+  // Configuration des écouteurs d'événements pour les changements de groupe
   useEffect(() => {
-    if (isCreatingGroup && inputRef.current) {
-      inputRef.current.focus();
-    }
-  }, [isCreatingGroup]);
+    const handleGroupChange = () => {
+      refreshGroupList();
+    };
 
-  // Gestion des touches Entrée et Escape pour l'input
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      createGroup();
-    } else if (e.key === "Escape") {
-      e.preventDefault();
-      setIsCreatingGroup(false);
-      setNewGroupName('');
-    }
-  };
+    document.addEventListener('groupCreated', handleGroupChange);
+    document.addEventListener('groupJoined', handleGroupChange);
+    document.addEventListener('groupLeft', handleGroupChange);
+
+    return () => {
+      document.removeEventListener('groupCreated', handleGroupChange);
+      document.removeEventListener('groupJoined', handleGroupChange);
+      document.removeEventListener('groupLeft', handleGroupChange);
+    };
+  }, [refreshGroupList]);
 
   return (
     <div className="bg-white h-full shadow-md flex-shrink-0 border-r border-gray-200 w-full overflow-hidden">
@@ -60,32 +41,15 @@ const SideMenu: React.FC = () => {
         <h2 className="text-lg font-medium text-gray-900 mb-4">{t('sidemenu.groups')}</h2>
 
         {/* Utilisation du composant GroupList */}
-        <GroupList />
+        <GroupList key={groupListKey} />
 
         <div className="mt-6 space-y-2">
-          {isCreatingGroup ? (
-            <div className="relative">
-              <input
-                ref={inputRef}
-                type="text"
-                value={newGroupName}
-                onChange={(e) => setNewGroupName(e.target.value)}
-                onKeyDown={handleKeyDown}
-                className="w-full px-4 py-2 text-sm border rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
-                placeholder={t('sidemenu.groupNamePlaceholder') || 'Enter group name...'}
-              />
-            </div>
-          ) : (
-            <button
-              onClick={() => setIsCreatingGroup(true)}
-              className="flex items-center px-4 py-2 text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 w-full"
-            >
-              <svg className="mr-3 h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-                <path fillRule="evenodd" d="M10 5a1 1 0 011 1v3h3a1 1 0 110 2h-3v3a1 1 0 11-2 0v-3H6a1 1 0 110-2h3V6a1 1 0 011-1z" clipRule="evenodd" />
-              </svg>
-              {t('sidemenu.createGroup')}
-            </button>
-          )}
+          {/* Utilisation du composant GroupCreationForm */}
+          <GroupCreationForm
+            className="mb-2"
+            refetchOnCreate={true}
+            onGroupCreated={handleGroupCreated}
+          />
 
           <Link
             to="/invitations"

--- a/src/hooks/useOutsideClick.ts
+++ b/src/hooks/useOutsideClick.ts
@@ -1,39 +1,33 @@
-import { useEffect, RefObject, useCallback } from 'react';
+import { useEffect, RefObject } from 'react';
 
 /**
- * Hook pour détecter les clics en dehors d'un élément spécifié
- * @param ref - Référence React à l'élément à surveiller
- * @param handler - Fonction à exécuter lorsqu'un clic est détecté en dehors de l'élément
- * @param active - Indique si la détection est active ou non (utile pour les modales conditionnelles)
+ * Hook qui permet de détecter les clics en dehors d'un élément référencé.
+ * @param ref La référence de l'élément à surveiller
+ * @param callback La fonction à appeler lorsqu'un clic est détecté en dehors de l'élément
+ * @param active Indique si la détection des clics extérieurs est active (par défaut: true)
  */
 const useOutsideClick = <T extends HTMLElement>(
   ref: RefObject<T | null>,
-  handler: () => void,
+  callback: () => void,
   active: boolean = true
 ): void => {
-  // Mémoriser le gestionnaire d'événements pour éviter des re-render inutiles
-  const memoizedHandler = useCallback(
-    (event: MouseEvent) => {
-      // Vérifier que la référence est définie et que le clic n'est pas à l'intérieur de l'élément
-      if (active && ref.current && !ref.current.contains(event.target as Node)) {
-        handler();
-      }
-    },
-    [ref, handler, active]
-  );
-
   useEffect(() => {
-    // N'ajouter l'écouteur que si le hook est actif
-    if (active) {
-      document.addEventListener('mousedown', memoizedHandler);
-
-      // Nettoyer l'écouteur à la désactivation du hook ou au démontage du composant
-      return () => {
-        document.removeEventListener('mousedown', memoizedHandler);
-      };
+    function handleClickOutside(event: MouseEvent) {
+      if (active && ref.current && !ref.current.contains(event.target as Node)) {
+        callback();
+      }
     }
-    return undefined;
-  }, [active, memoizedHandler]);
+
+    if (active) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+
+    return () => {
+      if (active) {
+        document.removeEventListener('mousedown', handleClickOutside);
+      }
+    };
+  }, [ref, callback, active]);
 };
 
 export default useOutsideClick;


### PR DESCRIPTION
This pull request includes significant changes to the `SideMenu` component and the `useOutsideClick` hook to enhance functionality and improve code clarity. The most important changes include the removal of unused imports, the introduction of the `GroupCreationForm` component, and the simplification of the `useOutsideClick` hook.

### Changes to `SideMenu` component:

* Removed unused imports `useRef` and `useOutsideClick` from `SideMenu.tsx` to clean up the code.
* Replaced the inline group creation logic with the `GroupCreationForm` component, simplifying the `SideMenu` component and improving code reuse.
* Added event listeners for `groupCreated`, `groupJoined`, and `groupLeft` events to refresh the group list dynamically.

### Changes to `useOutsideClick` hook:

* Simplified the `useOutsideClick` hook by removing the `useCallback` hook and directly defining the `handleClickOutside` function within the `useEffect` hook.
* Renamed the `handler` parameter to `callback` to better reflect its purpose.…k useOutsideClick