### PR TITLE
feat: update translation files for user profiles and groups

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -339,7 +339,8 @@
     "sendInvitation": "Send Invitation",
     "invitationSent": "Invitation sent successfully!",
     "errorSendingInvitation": "Error sending invitation. Please try again.",
-    "errorGettingInvitationLink": "Error getting invitation link. A simpler link has been generated."
+    "errorGettingInvitationLink": "Error getting invitation link. A simpler link has been generated.",
+    "errorGettingGroups": "Error getting groups. Please try again."
   },
   "giftIdeas": {
     "title": "Gift Ideas",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -337,7 +337,10 @@
     "sendInvitation": "Envoyer l'invitation",
     "invitationSent": "Invitation envoyée avec succès !",
     "errorSendingInvitation": "Erreur lors de l'envoi de l'invitation. Veuillez réessayer.",
-    "errorGettingInvitationLink": "Erreur lors de la récupération du lien d'invitation. Un lien plus simple a été généré."
+    "errorGettingInvitationLink": "Erreur lors de la récupération du lien d'invitation. Un lien plus simple a été généré.",
+    "errorGettingGroups": "Erreur lors de la récupération des groupes. Veuillez réessayer.",
+    "errorUpdatingRole": "Erreur lors de la mise à jour du rôle. Veuillez réessayer.",
+    "errorRemovingMember": "Erreur lors de la suppression du membre. Veuillez réessayer."
   },
   "giftIdeas": {
     "title": "Idées de cadeaux",
@@ -386,10 +389,10 @@
     "group": "Groupe",
     "actions": "Actions",
     "markAsBuying": "Je vais l'acheter",
-    "markAsBought": "J'ai acheté",
+    "markAsBought": "Je l'ai acheté",
     "visitStore": "Visiter la boutique",
     "errorMarkingAsBuying": "Erreur lors du marquage comme \"Je vais l'acheter\"",
-    "errorMarkingAsBought": "Erreur lors du marquage comme \"J'ai acheté\"",
+    "errorMarkingAsBought": "Erreur lors du marquage comme \"Je l'ai acheté\"",
     "notFound": "Idée cadeau non trouvée",
     "imageLabel": "Image",
     "created": "Idée cadeau créée avec succès",


### PR DESCRIPTION
This pull request includes updates to the translation files for both English and French locales, adding new error messages and correcting existing translations.

### Updates to translation files:

* [`public/locales/en/translation.json`](diffhunk://#diff-8e77946ee485378b13babd5fe6bdc1707b77dce605ac6723d7a5b4494dc94925L342-R343): Added a new error message for fetching groups.
* `public/locales/fr/translation.json`: 
  * Added new error messages for fetching groups, updating roles, and removing members.
  * Corrected the translation for "mark as bought" to "Je l'ai acheté".