### PR TITLE
refactor: Reorganize type imports for better maintainability

### DIFF
--- a/src/components/common/display/Testimonial.tsx
+++ b/src/components/common/display/Testimonial.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TestimonialProps } from '../../../types';
+import { TestimonialProps } from '../../../types/ui';
 
 const Testimonial: React.FC<TestimonialProps> = ({
   content,

--- a/src/components/common/display/TestimonialSlider.tsx
+++ b/src/components/common/display/TestimonialSlider.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import Testimonial from './Testimonial';
-import { TestimonialSliderProps } from '../../../types';
+import { TestimonialSliderProps } from '../../../types/ui';
 
 const TestimonialSlider: React.FC<TestimonialSliderProps> = ({
   testimonials,

--- a/src/components/common/display/__tests__/Image.test.tsx
+++ b/src/components/common/display/__tests__/Image.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import Image from '../Image';
 

--- a/src/components/common/display/__tests__/LabelValue.test.tsx
+++ b/src/components/common/display/__tests__/LabelValue.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import LabelValue from '../LabelValue';
 

--- a/src/components/common/display/__tests__/TestimonialSlider.test.tsx
+++ b/src/components/common/display/__tests__/TestimonialSlider.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import TestimonialSlider from '../TestimonialSlider';
-import { TestimonialProps } from '../Testimonial';
+import { TestimonialProps } from '../../../../types/ui';
 
 // Mock des intervalles pour les tests
 jest.useFakeTimers();

--- a/src/components/common/forms/__tests__/GroupCreationForm.test.tsx
+++ b/src/components/common/forms/__tests__/GroupCreationForm.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import GroupCreationForm from '../GroupCreationForm';

--- a/src/components/common/seo/SEO.tsx
+++ b/src/components/common/seo/SEO.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import useMetaTags from '../../../hooks/useMetaTags';
-import { SEOProps } from '../../../types';
+import { SEOProps } from '../../../types/seo';
 
 /**
  * Composant SEO qui utilise le hook useMetaTags pour mettre à jour les métadonnées de la page

--- a/src/components/gift-ideas/__tests__/GiftIdeaDetailCard.test.tsx
+++ b/src/components/gift-ideas/__tests__/GiftIdeaDetailCard.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import GiftIdeaDetailCard from '../GiftIdeaDetailCard';
 
@@ -30,6 +29,7 @@ describe('GiftIdeaDetailCard Component', () => {
       { id: 'user2', name: 'Jane Smith' },
     ],
     group_name: 'Test Group',
+    group_id: 'group1',
   };
 
   const mockCurrentUser = {

--- a/src/components/groups/GroupItemsList.tsx
+++ b/src/components/groups/GroupItemsList.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Card from '../common/display/Card';
 import Button from '../common/forms/Button';
 import { GroupItemsListProps } from '../../types/groups';

--- a/src/types/seo.ts
+++ b/src/types/seo.ts
@@ -29,7 +29,11 @@ export interface MetaTagsOptions {
 }
 
 /**
- * Props pour le composant SEO
+ * Types pour les composants SEO
+ */
+
+/**
+ * Propriétés pour le composant SEO
  */
 export interface SEOProps {
   title?: string;
@@ -37,7 +41,7 @@ export interface SEOProps {
   keywords?: string[];
   image?: string;
   url?: string;
-  type?: 'website' | 'article' | 'product';
+  type?: string;
   author?: string;
   twitterUsername?: string;
   publishedTime?: string;

--- a/src/types/social.ts
+++ b/src/types/social.ts
@@ -19,6 +19,7 @@ export interface SocialNetwork {
   url: string;
   icon: ReactNode;
   label?: string;
+  ariaLabel?: string;
 }
 
 /**

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -9,10 +9,10 @@
 
     /* Bundler mode */
     "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
+    "allowImportingTsExtensions": false,
     "isolatedModules": true,
     "moduleDetection": "force",
-    "noEmit": true,
+    "noEmit": false,
     "jsx": "react-jsx",
     "esModuleInterop": true,
 

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -11,7 +11,7 @@
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",
-    "noEmit": true,
+    "noEmit": false,
 
     /* Linting */
     "strict": true,


### PR DESCRIPTION
This pull request includes several changes to improve type imports, remove unnecessary React imports, and update TypeScript configurations. Here are the most important changes:

### Type Imports:

* [`src/components/common/display/Testimonial.tsx`](diffhunk://#diff-16fa0a7806d1b15502e1c59f8ad9cde13e61d79d94026fa05b78361a1a9f2e32L2-R2): Changed the import path for `TestimonialProps` to `../../../types/ui`.
* [`src/components/common/display/TestimonialSlider.tsx`](diffhunk://#diff-06ddebd88811742a5542718df57d872f8003019914991cff5d214f2c861f3642L3-R3): Changed the import path for `TestimonialSliderProps` to `../../../types/ui`.
* [`src/components/common/seo/SEO.tsx`](diffhunk://#diff-d7c2457d288545f14f435305c26911d2dfb285c1632b72ac83925f9f8bde13a5L4-R4): Changed the import path for `SEOProps` to `../../../types/seo`.
* [`src/components/common/display/__tests__/TestimonialSlider.test.tsx`](diffhunk://#diff-60680e7f42e1c5914c848c727cbc958a7896fa6fc0adc4c1f4808b3625280857L4-R4): Changed the import path for `TestimonialProps` to `../../../../types/ui`.

### React Imports:

* Removed unnecessary React imports from test files:
  * `src/components/common/display/__tests__/Image.test.tsx`
  * `src/components/common/display/__tests__/LabelValue.test.tsx`
  * `src/components/common/forms/__tests__/GroupCreationForm.test.tsx`
  * `src/components/gift-ideas/__tests__/GiftIdeaDetailCard.test.tsx`
  * `src/components/groups/GroupItemsList.tsx`

### TypeScript Configurations:

* [`tsconfig.app.json`](diffhunk://#diff-e71ce96b0b270cb476d6bd8c44bf0cdf6f0db749e316374a54f1b14aff8d63ddL12-R15): Changed `allowImportingTsExtensions` to `false` and `noEmit` to `false`.
* [`tsconfig.node.json`](diffhunk://#diff-fe25c5935d7e03a4c85624008426c631b83d3afccbd792e41549cb74ce945118L14-R14): Changed `noEmit` to `false`.

### Other Changes:

* [`src/types/seo.ts`](diffhunk://#diff-733c55a4aa88e6c0a5c7aa9ed44dc8f0a08438dd2ead6248704d177e856e4113L32-R44): Updated the `SEOProps` interface to change the `type` property to `string`.
* [`src/types/social.ts`](diffhunk://#diff-b71b8b06fdff9ab4d3404221ca62511c6a877afb9f17b5816be92559a8850a46R22): Added an optional `ariaLabel` property to the `SocialNetwork` interface.
* [`src/components/gift-ideas/__tests__/GiftIdeaDetailCard.test.tsx`](diffhunk://#diff-f65316f3a2be5f7269a103e4e8d271aab04e6e138efddd4dbb068606451939bbR32): Added `group_id` to the mock group object.