### PR TITLE
hotfix: when joining a group already joined reidurect to the group

### DIFF
--- a/src/pages/invitation/InvitationJoin.tsx
+++ b/src/pages/invitation/InvitationJoin.tsx
@@ -101,15 +101,21 @@ const InvitationJoin: React.FC = () => {
       setIsAccepting(true);
       const response = await invitationService.acceptInvitation(token, selectedUserIds);
 
-      // Afficher un message de succès
+      // Afficher un message de succès ou rediriger si déjà membre
       if (response.success) {
-        setStatus('success');
-        // Rediriger vers la page du groupe après 2 secondes
-        setTimeout(() => {
-          if (invitationGroupId) {
-            navigate(`/groups/${invitationGroupId}`);
-          }
-        }, 2000);
+        const groupId = response.group?.id ?? invitationGroupId;
+        if (response.already_member && groupId) {
+          // Déjà membre : redirection immédiate vers le groupe
+          navigate(`/groups/${groupId}`);
+        } else {
+          setStatus('success');
+          // Rediriger vers la page du groupe après 2 secondes
+          setTimeout(() => {
+            if (groupId) {
+              navigate(`/groups/${groupId}`);
+            }
+          }, 2000);
+        }
       } else {
         setStatus('error');
         setErrorMessage(response.message || t('invitation:errorAccepting'));


### PR DESCRIPTION
This pull request improves the user experience when accepting an invitation to join a group. Now, if a user is already a member of the group, they are redirected immediately to the group page instead of seeing a success message and waiting for a delay.

Enhancements to invitation acceptance flow:

* Updated the invitation acceptance logic in `InvitationJoin.tsx` so that if the user is already a member of the group, they are redirected immediately to the group page; otherwise, the existing behavior of showing a success message and redirecting after a delay is preserved.