### PR TITLE
feat: add a button to cancel a purchase

### DIFF
--- a/public/locales/en/dashboard.json
+++ b/public/locales/en/dashboard.json
@@ -24,7 +24,8 @@
     "loadingData": "Error loading data",
     "loadingEvents": "Error loading events",
     "loadingGifts": "Error loading gifts",
-    "markingGift": "Error marking gift as bought"
+    "markingGift": "Error marking gift as bought",
+    "cancellingPurchase": "Error cancelling purchase"
   },
   "cards": {
     "gifts": {

--- a/public/locales/en/gifts.json
+++ b/public/locales/en/gifts.json
@@ -65,6 +65,7 @@
     "markAsBuying": "I'm buying this",
     "markAsBought": "I've bought this",
     "markAsBoughtFor": "{{name}} bought this",
+    "cancelPurchase": "Cancel purchase",
     "selectBuyer": "Who will buy this gift?",
     "selectBuyerDescription": "Multiple accounts can buy this gift. Select who will make the purchase.",
     "visitStore": "Visit store",

--- a/public/locales/fr/dashboard.json
+++ b/public/locales/fr/dashboard.json
@@ -24,7 +24,8 @@
     "loadingData": "Erreur lors du chargement des données",
     "loadingEvents": "Erreur lors du chargement des événements",
     "loadingGifts": "Erreur lors du chargement des cadeaux",
-    "markingGift": "Erreur lors du marquage du cadeau comme acheté"
+    "markingGift": "Erreur lors du marquage du cadeau comme acheté",
+    "cancellingPurchase": "Erreur lors de l'annulation de l'achat"
   },
   "cards": {
     "gifts": {

--- a/public/locales/fr/gifts.json
+++ b/public/locales/fr/gifts.json
@@ -51,6 +51,7 @@
     "markAsBuying": "Je vais l'acheter",
     "markAsBought": "Je l'ai acheté",
     "markAsBoughtFor": "{{name}} l'a acheté",
+    "cancelPurchase": "Annuler l'achat",
     "selectBuyer": "Qui va acheter ce cadeau ?",
     "selectBuyerDescription": "Plusieurs comptes peuvent acheter ce cadeau. Sélectionnez qui va effectuer l'achat.",
     "visitStore": "Visiter la boutique",

--- a/src/components/dashboard/BuyingGiftItem.tsx
+++ b/src/components/dashboard/BuyingGiftItem.tsx
@@ -11,9 +11,10 @@ export type { BuyingGift as GiftIdea };
 const BuyingGiftItem: React.FC<BuyingGiftItemProps> = ({
   gift,
   onMarkAsBought,
+  onCancelPurchase,
   isProcessing = false
 }) => {
-  const { t } = useTranslation('dashboard');
+  const { t } = useTranslation(['dashboard', 'gifts']);
   const navigate = useNavigate();
 
   const handleViewGift = () => {
@@ -37,28 +38,40 @@ const BuyingGiftItem: React.FC<BuyingGiftItemProps> = ({
           </p>
         </div>
       </div>
-      <div className="mt-2 flex gap-4 items-center">
+      <div className="mt-2 flex gap-4 items-center flex-wrap">
         <FlatButton
           onClick={handleViewGift}
           size="small"
         >
           {t('dashboard:viewGift')}
         </FlatButton>
-        <FlatButton
-          variant="secondary"
-          size="small"
-          onClick={() => onMarkAsBought(gift.id)}
-          disabled={isProcessing}
-        >
-          {isProcessing ? (
-            <>
-              <span className="inline-block h-4 w-4 rounded-full border-2 border-t-transparent border-white animate-spin mr-2" />
-              {t('common:processing')}
-            </>
-          ) : (
-            t('dashboard:markAsBought')
-          )}
-        </FlatButton>
+        {gift.status === 'buying' && (
+          <FlatButton
+            variant="secondary"
+            size="small"
+            onClick={() => onMarkAsBought(gift.id)}
+            disabled={isProcessing}
+          >
+            {isProcessing ? (
+              <>
+                <span className="inline-block h-4 w-4 rounded-full border-2 border-t-transparent border-white animate-spin mr-2" />
+                {t('common:processing')}
+              </>
+            ) : (
+              t('dashboard:markAsBought')
+            )}
+          </FlatButton>
+        )}
+        {gift.can_cancel_purchase && onCancelPurchase && (
+          <FlatButton
+            variant="secondary"
+            size="small"
+            onClick={() => onCancelPurchase(gift.id)}
+            disabled={isProcessing}
+          >
+            {t('gifts:giftIdeas.cancelPurchase')}
+          </FlatButton>
+        )}
       </div>
     </li>
   );

--- a/src/components/dashboard/BuyingGiftsList.tsx
+++ b/src/components/dashboard/BuyingGiftsList.tsx
@@ -44,6 +44,21 @@ const BuyingGiftsList: React.FC<BuyingGiftsListProps> = ({ maxGifts = 5 }) => {
     refetch: fetchGifts
   } = useAsyncData<ApiGiftIdeasResponse>(fetchUserGifts);
 
+  // Annuler l'achat (en cours d'achat ou déjà marqué acheté)
+  const handleCancelPurchase = async (giftId: string) => {
+    try {
+      setProcessingGiftId(giftId);
+      setActionError(null);
+      await giftIdeaService.cancelPurchase(giftId);
+      fetchGifts();
+    } catch (error) {
+      console.error('Error cancelling purchase:', error);
+      setActionError(t('dashboard:errors.cancellingPurchase'));
+    } finally {
+      setProcessingGiftId(null);
+    }
+  };
+
   // Marquer un cadeau comme acheté
   const handleMarkAsBought = async (giftId: string) => {
     try {
@@ -112,7 +127,8 @@ const BuyingGiftsList: React.FC<BuyingGiftsListProps> = ({ maxGifts = 5 }) => {
           name: r.name
         })),
         group_name: groupName,
-        status: gift.status as 'proposed' | 'buying' | 'bought'
+        status: gift.status as 'proposed' | 'buying' | 'bought',
+        can_cancel_purchase: gift.can_cancel_purchase ?? false
       };
     });
 
@@ -174,6 +190,7 @@ const BuyingGiftsList: React.FC<BuyingGiftsListProps> = ({ maxGifts = 5 }) => {
               key={gift.id}
               gift={gift}
               onMarkAsBought={handleMarkAsBought}
+              onCancelPurchase={handleCancelPurchase}
               isProcessing={processingGiftId === gift.id}
             />
           ))}

--- a/src/components/gift-ideas/GiftIdeaDetailCard.tsx
+++ b/src/components/gift-ideas/GiftIdeaDetailCard.tsx
@@ -15,6 +15,7 @@ const GiftIdeaDetailCard: React.FC<GiftIdeaDetailCardProps> = ({
   currentUser,
   onMarkAsBuying,
   onMarkAsBought,
+  onCancelPurchase,
   formatPrice
 }) => {
   const { t } = useTranslation('gifts');
@@ -22,6 +23,7 @@ const GiftIdeaDetailCard: React.FC<GiftIdeaDetailCardProps> = ({
   // Permissions calculées par le backend
   const canMarkAsBuying = giftIdea?.can_mark_as_buying ?? false;
   const canMarkAsBought = giftIdea?.can_mark_as_bought ?? false;
+  const canCancelPurchase = giftIdea?.can_cancel_purchase ?? false;
 
   // Vérifier si l'utilisateur est le destinataire
   const isRecipient = (): boolean => {
@@ -44,7 +46,7 @@ const GiftIdeaDetailCard: React.FC<GiftIdeaDetailCardProps> = ({
 
   // Rendu des boutons d'action
   const renderActionButtons = () => {
-    const hasActions = canMarkAsBuying || canMarkAsBought || giftIdea.link;
+    const hasActions = canMarkAsBuying || canMarkAsBought || canCancelPurchase || giftIdea.link;
     
     if (!hasActions) return null;
 
@@ -71,6 +73,11 @@ const GiftIdeaDetailCard: React.FC<GiftIdeaDetailCardProps> = ({
         {canMarkAsBought && (
           <Button variant="primary" onClick={onMarkAsBought}>
             {getMarkAsBoughtText()}
+          </Button>
+        )}
+        {canCancelPurchase && onCancelPurchase && (
+          <Button variant="outline" onClick={onCancelPurchase}>
+            {t('gifts:giftIdeas.cancelPurchase')}
           </Button>
         )}
 

--- a/src/components/gift-ideas/GiftIdeaDetailCard.tsx
+++ b/src/components/gift-ideas/GiftIdeaDetailCard.tsx
@@ -47,7 +47,7 @@ const GiftIdeaDetailCard: React.FC<GiftIdeaDetailCardProps> = ({
   // Rendu des boutons d'action
   const renderActionButtons = () => {
     const hasActions = canMarkAsBuying || canMarkAsBought || canCancelPurchase || giftIdea.link;
-    
+
     if (!hasActions) return null;
 
     // Déterminer le texte du bouton "Mark as bought" avec le nom de l'acheteur
@@ -65,6 +65,11 @@ const GiftIdeaDetailCard: React.FC<GiftIdeaDetailCardProps> = ({
 
     return (
       <div className="flex gap-2 mb-4 flex-wrap">
+        {canCancelPurchase && onCancelPurchase && (
+          <Button variant="danger" onClick={onCancelPurchase}>
+            {t('gifts:giftIdeas.cancelPurchase')}
+          </Button>
+        )}
         {canMarkAsBuying && (
           <Button variant="primary" onClick={onMarkAsBuying}>
             {t('gifts:giftIdeas.markAsBuying')}
@@ -73,11 +78,6 @@ const GiftIdeaDetailCard: React.FC<GiftIdeaDetailCardProps> = ({
         {canMarkAsBought && (
           <Button variant="primary" onClick={onMarkAsBought}>
             {getMarkAsBoughtText()}
-          </Button>
-        )}
-        {canCancelPurchase && onCancelPurchase && (
-          <Button variant="outline" onClick={onCancelPurchase}>
-            {t('gifts:giftIdeas.cancelPurchase')}
           </Button>
         )}
 

--- a/src/pages/GiftIdeaDetails.tsx
+++ b/src/pages/GiftIdeaDetails.tsx
@@ -142,6 +142,18 @@ const GiftIdeaDetails: React.FC = () => {
     }
   };
 
+  // Annuler l'achat (en cours d'achat ou déjà marqué acheté)
+  const handleCancelPurchase = async () => {
+    if (!id) return;
+
+    try {
+      const response = await giftIdeaService.cancelPurchase(id);
+      setGiftIdea(response.giftIdea as ExtendedGiftIdea);
+    } catch (error) {
+      console.error('Error cancelling purchase:', error);
+    }
+  };
+
   // Gérer la suppression de l'idée cadeau
   const handleDeleteGiftIdea = async () => {
     if (!id) return;
@@ -286,6 +298,7 @@ const GiftIdeaDetails: React.FC = () => {
         currentUser={user}
         onMarkAsBuying={handleMarkAsBuying}
         onMarkAsBought={handleMarkAsBought}
+        onCancelPurchase={handleCancelPurchase}
         formatPrice={formatPrice}
       />
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -352,6 +352,12 @@ export const giftIdeaService = {
     const response = await api.put(`/gift_ideas/${id}/mark_as_bought`);
     return response.data;
   },
+
+  // Annuler l'achat (en cours d'achat ou déjà marqué acheté)
+  cancelPurchase: async (id: string) => {
+    const response = await api.put(`/gift_ideas/${id}/cancel_purchase`);
+    return response.data;
+  },
 };
 
 // Service pour les invitations

--- a/src/types/gift-ideas.ts
+++ b/src/types/gift-ideas.ts
@@ -100,6 +100,7 @@ export interface GiftIdeaDetailCardProps {
   currentUser: User | null;
   onMarkAsBuying: () => void;
   onMarkAsBought: () => void;
+  onCancelPurchase?: () => void;
   formatPrice: (price?: number) => string;
 }
 
@@ -132,6 +133,7 @@ export interface BuyingGift {
   recipients?: Array<{id: string, name: string}>;
   group_name: string;
   status: GiftStatus;
+  can_cancel_purchase?: boolean;
 }
 
 /**
@@ -140,6 +142,7 @@ export interface BuyingGift {
 export interface BuyingGiftItemProps {
   gift: BuyingGift;
   onMarkAsBought: (giftId: string) => void;
+  onCancelPurchase?: (giftId: string) => void;
   isProcessing?: boolean;
 }
 
@@ -179,6 +182,7 @@ export interface ApiGiftIdea {
   image_url?: string;
   buyer?: { id: number | string; name: string };
   buyer_id?: number | string;
+  can_cancel_purchase?: boolean;
 }
 
 /**
@@ -202,6 +206,7 @@ export interface ExtendedGiftIdea extends GiftIdea {
   can_mark_as_buying?: boolean;
   can_mark_as_bought?: boolean;
   can_cancel_buying?: boolean;
+  can_cancel_purchase?: boolean;
 }
 
 /**


### PR DESCRIPTION
This pull request adds support for cancelling a gift purchase in the dashboard and gift idea details, including UI, API integration, and localization updates. Users can now cancel a purchase if allowed, and the feature is available in both English and French. The changes also update the relevant types and props to support the new action.

**Feature: Cancel Gift Purchase**

* Added a "Cancel purchase" button in both the `BuyingGiftItem` and `GiftIdeaDetailCard` components, shown when `can_cancel_purchase` is true. This allows users to cancel a gift purchase if permitted. [[1]](diffhunk://#diff-200b1deae3eacbd5753ff45def5132f7ab12816d03d10e7453ca75574d1d8580R64-R74) [[2]](diffhunk://#diff-6e4354a84cab3694d0098e4a94e460dd64cb1428ba910cc220720ffe2f98a59cR78-R82)
* Implemented `handleCancelPurchase` logic in both the dashboard (`BuyingGiftsList`) and gift idea details (`GiftIdeaDetails`) to call the new API endpoint and handle UI updates and errors. [[1]](diffhunk://#diff-acfcc89960dca153358e9646e536b81f1360ad23a5e766413bc9be0eeb6e4733R47-R61) [[2]](diffhunk://#diff-9e382d7bf690c3200c4c09dd79e922ec109ebd2911132cd88634518c46865aefR145-R156)

**API and Type Updates**

* Added the `cancelPurchase` method to `giftIdeaService` for calling the backend endpoint.
* Updated TypeScript interfaces (`BuyingGift`, `ApiGiftIdea`, `ExtendedGiftIdea`, and component props) to include `can_cancel_purchase` and the new handler where needed. [[1]](diffhunk://#diff-82f79a75e692d730501575f23cee8c5b8a71beaba62ffc86ded77b5334d68689R136) [[2]](diffhunk://#diff-82f79a75e692d730501575f23cee8c5b8a71beaba62ffc86ded77b5334d68689R145) [[3]](diffhunk://#diff-82f79a75e692d730501575f23cee8c5b8a71beaba62ffc86ded77b5334d68689R185) [[4]](diffhunk://#diff-82f79a75e692d730501575f23cee8c5b8a71beaba62ffc86ded77b5334d68689R209) [[5]](diffhunk://#diff-82f79a75e692d730501575f23cee8c5b8a71beaba62ffc86ded77b5334d68689R103)

**Localization**

* Added English and French translations for "Cancel purchase" and related error messages in both dashboard and gifts locales. [[1]](diffhunk://#diff-ec92c42bca9ea62d0c034dc7ef15e54f778be0e1ff24d2d61af6cbd028c8cad6R68) [[2]](diffhunk://#diff-cd33038bc9d2f1b838015af69bfbb96b45e23487cd7ddadfcf259d47d79bfed2R54) [[3]](diffhunk://#diff-acc9900a7ddae31f668ca7f8d77c6e912e428eb4b41883a323192b6ad95c60c0L27-R28) [[4]](diffhunk://#diff-8bb3105f700cd858cd5d6e4ea1396e9f8c49fef6bf3a8109c30e72857f6a8e5bL27-R28)